### PR TITLE
Move settings to XDG_CONFIG_HOME

### DIFF
--- a/de.mediathekview.MediathekView.sh
+++ b/de.mediathekview.MediathekView.sh
@@ -8,4 +8,5 @@ exec java \
     -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=compact -XX:MaxRAMPercentage=50.0 -XX:+UseStringDeduplication \
     --add-opens java.desktop/sun.awt.X11=ALL-UNNAMED \
     -DexternalUpdateCheck \
-    -jar /app/share/de.mediathekview.MediathekView/MediathekView.jar "$@"
+    -jar /app/share/de.mediathekview.MediathekView/MediathekView.jar \
+    "${XDG_CONFIG_HOME}/mediathek3"

--- a/de.mediathekview.MediathekView.yaml
+++ b/de.mediathekview.MediathekView.yaml
@@ -19,10 +19,6 @@ finish-args:
   - '--talk-name=org.freedesktop.Notifications'   # For desktop notifications
   - '--filesystem=xdg-download' # Standard directory for downloads
   - '--talk-name=org.freedesktop.Flatpak' # to launch the VLC flatpak
-  # Persist Mediathekview config directories; it doesn't use XDG_CONFIG_HOME unfortunately, see
-  # https://github.com/mediathekview/MediathekView/issues/339
-  - '--persist=.mediathek3'
-  - '--persist=.mediathek.javafx.tool.JFXHiddenApplication/'
   # See https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk#usage
   - '--env=PATH=/app/bin/:/app/jre/bin:/usr/bin'
 cleanup-commands:

--- a/de.mediathekview.MediathekView.yaml
+++ b/de.mediathekview.MediathekView.yaml
@@ -16,8 +16,13 @@ finish-args:
   - '--share=ipc' # Required for X11
   - '--device=dri' # Render things with opengl
   - '--socket=pulseaudio' # Sound
+  # Expose all of $HOME because being a Java app mediathekview doesn't use
+  # portals and lets users use arbitrary download directories.  Restricting file
+  # system access further would be confusing because the home directory would
+  # look different in the Java directory chooser, and users would likely miss
+  # downloaded files. See https://github.com/flathub/de.mediathekview.MediathekView/issues/7
+  - '--filesystem=home'
   - '--talk-name=org.freedesktop.Notifications'   # For desktop notifications
-  - '--filesystem=xdg-download' # Standard directory for downloads
   - '--talk-name=org.freedesktop.Flatpak' # to launch the VLC flatpak
   # See https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk#usage
   - '--env=PATH=/app/bin/:/app/jre/bin:/usr/bin'


### PR DESCRIPTION
While mediathekview doesn't support XDG_CONFIG_HOME directly it features a portable mode where we can essentially pass the configuration directory as argument to the application.

We can (ab-)use this to move all settings under XDG_CONFIG_HOME which allows us to get rid of --persist finish args.