### PR TITLE
Create /app/lib/ffmpeg after build

### DIFF
--- a/de.mediathekview.MediathekView.yaml
+++ b/de.mediathekview.MediathekView.yaml
@@ -26,6 +26,10 @@ finish-args:
   - "--talk-name=org.freedesktop.Flatpak" # to launch the VLC flatpak
   # See https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk#usage
   - "--env=PATH=/app/bin/:/app/jre/bin:/usr/bin"
+cleanup-commands:
+  # Create ffmpeg libdir so that ldconfig doesn't fail when the flatpak starts.
+  # See https://github.com/flathub/de.mediathekview.MediathekView/issues/14
+  - "mkdir -p /app/lib/ffmpeg"
 modules:
   # See https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk#usage
   - name: openjdk


### PR DESCRIPTION
Apparently, ldconfig wants this directory to be existing, but it can't create it as the libdir of flatpaks is read-only. So let's create it for ldconfig.

Closes #14

This reverts commit 4071b724763d43f30de0084bf171c68e89b7a69d.